### PR TITLE
Pass `-nologo` as argument to `mt.exe`

### DIFF
--- a/build/Unpackaged.targets
+++ b/build/Unpackaged.targets
@@ -30,7 +30,7 @@
   <Target Name="_UnpackagedWin32GenerateAdditionalWinmdManifests" Inputs="@(_UnpackagedWin32WinmdManifest.WinMDPath)" Outputs="@(_UnpackagedWin32WinmdManifest)" DependsOnTargets="_UnpackagedWin32MapWinmdsToManifestFiles">
     <Message Text="Generating manifest for %(_UnpackagedWin32WinmdManifest.WinMDPath)" Importance="High" />
     <!-- This target is batched and a new Exec is spawned for each entry in _UnpackagedWin32WinmdManifest. -->
-    <Exec Command="mt.exe -winmd:%(_UnpackagedWin32WinmdManifest.WinMDPath) -dll:%(_UnpackagedWin32WinmdManifest.Implementation) -out:%(_UnpackagedWin32WinmdManifest.Identity)" />
+    <Exec Command="mt.exe -winmd:%(_UnpackagedWin32WinmdManifest.WinMDPath) -dll:%(_UnpackagedWin32WinmdManifest.Implementation) -out:%(_UnpackagedWin32WinmdManifest.Identity) -nologo" />
     <ItemGroup>
       <!-- Emit the generated manifest into the Link inputs. -->
       <Manifest Include="@(_UnpackagedWin32WinmdManifest)" />


### PR DESCRIPTION
Just a minor tweak to make logging look a little nicer.

## Build output before:

```
4>------ Build started: Project: Blah, Configuration: Debug x64 ------
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Microsoft (R) Manifest Tool
4>
4>Copyright (c) Microsoft Corporation.
4>
4>All rights reserved.
4>
4>Microsoft (R) Manifest Tool
4>
4>Copyright (c) Microsoft Corporation.
4>
4>All rights reserved.
4>
4>Microsoft (R) Manifest Tool
4>
4>Copyright (c) Microsoft Corporation.
4>
4>All rights reserved.
4>
4>Microsoft (R) Manifest Tool
4>
4>Copyright (c) Microsoft Corporation.
4>
4>All rights reserved.
4>
4>Microsoft (R) Manifest Tool
4>
4>Copyright (c) Microsoft Corporation.
4>
4>All rights reserved.
4>
4>Microsoft (R) Manifest Tool
4>
4>Copyright (c) Microsoft Corporation.
4>
4>All rights reserved.
4>
4>Microsoft (R) Manifest Tool
4>
4>Copyright (c) Microsoft Corporation.
4>
4>All rights reserved.
4>
4>Blah.vcxproj -> C:\path\to\Blah.exe
4>I4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>========== Build: 4 succeeded, 0 failed, 10 up-to-date, 1 skipped ==========
```

## Build output after
```
Build started...
4>------ Build started: Project: Blah, Configuration: Debug x64 ------
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Generating manifest for C:\path\to\some.winmd
4>Blah.vcxproj -> C:\path\to\Blah.exe
4>I4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>4>========== Build: 4 succeeded, 0 failed, 10 up-to-date, 1 skipped ==========
```