### PR TITLE
Fix _UnpackagedWin32GenerateAdditionalWinmdManifests passing superfluous metadata

### DIFF
--- a/CppXAMLSample/XamlIslandsSample/WindowsProject1.vcxproj
+++ b/CppXAMLSample/XamlIslandsSample/WindowsProject1.vcxproj
@@ -236,8 +236,9 @@
     <!-- This target is batched and a new Exec is spawned for each entry in _UnpackagedWin32WinmdManifest. -->
     <Exec Command="mt.exe -winmd:%(_UnpackagedWin32WinmdManifest.WinMDPath) -dll:%(_UnpackagedWin32WinmdManifest.Implementation) -out:%(_UnpackagedWin32WinmdManifest.Identity)" />
     <ItemGroup>
-      <!-- Emit the generated manifest into the Link inputs. -->
-      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" />
+     <!-- Emit the generated manifest into the Link inputs. Pass a metadata name that isn't used to wipe all 
+          metadata because otherwise VS tries copying the manifest to the output as %(FileName).winmd. -->
+      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" KeepMetadata="DoesntExist" />
     </ItemGroup>
   </Target>
   <ItemDefinitionGroup>

--- a/build/Unpackaged.targets
+++ b/build/Unpackaged.targets
@@ -32,8 +32,9 @@
     <!-- This target is batched and a new Exec is spawned for each entry in _UnpackagedWin32WinmdManifest. -->
     <Exec Command="mt.exe -winmd:%(_UnpackagedWin32WinmdManifest.WinMDPath) -dll:%(_UnpackagedWin32WinmdManifest.Implementation) -out:%(_UnpackagedWin32WinmdManifest.Identity) -nologo" />
     <ItemGroup>
-      <!-- Emit the generated manifest into the Link inputs. -->
-      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" />
+     <!-- Emit the generated manifest into the Link inputs. Pass a metadata name that isn't used to wipe all 
+          metadata because otherwise VS tries copying the manifest to the output as %(FileName).winmd. -->
+      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" KeepMetadata="DoesntExist" />
     </ItemGroup>
   </Target>
 

--- a/readme.md
+++ b/readme.md
@@ -310,8 +310,9 @@ Things you'll need to worry about:
     <!-- This target is batched and a new Exec is spawned for each entry in _UnpackagedWin32WinmdManifest. -->
     <Exec Command="mt.exe -winmd:%(_UnpackagedWin32WinmdManifest.WinMDPath) -dll:%(_UnpackagedWin32WinmdManifest.Implementation) -out:%(_UnpackagedWin32WinmdManifest.Identity)" />
     <ItemGroup>
-      <!-- Emit the generated manifest into the Link inputs. -->
-      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" />
+     <!-- Emit the generated manifest into the Link inputs. Pass a metadata name that isn't used to wipe all 
+          metadata because otherwise VS tries copying the manifest to the output as %(FileName).winmd. -->
+      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" KeepMetadata="DoesntExist" />
     </ItemGroup>
   </Target>
 ```

--- a/win32/WindowsProject1.vcxproj
+++ b/win32/WindowsProject1.vcxproj
@@ -220,8 +220,9 @@
     <!-- This target is batched and a new Exec is spawned for each entry in _UnpackagedWin32WinmdManifest. -->
     <Exec Command="mt.exe -winmd:%(_UnpackagedWin32WinmdManifest.WinMDPath) -dll:%(_UnpackagedWin32WinmdManifest.Implementation) -out:%(_UnpackagedWin32WinmdManifest.Identity)" />
     <ItemGroup>
-      <!-- Emit the generated manifest into the Link inputs. -->
-      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" />
+     <!-- Emit the generated manifest into the Link inputs. Pass a metadata name that isn't used to wipe all 
+          metadata because otherwise VS tries copying the manifest to the output as %(FileName).winmd. -->
+      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" KeepMetadata="DoesntExist" />
     </ItemGroup>
   </Target>
   <!--


### PR DESCRIPTION
Because of this superfluous metadata, the autogenerated manifest could end up copied to the output with its extension changed to winmd if the original winmd isn't copied to the output.