### PR TITLE
Support Segoe UI Variable as default font

### DIFF
--- a/CppXAMLSample/XamlIslandsSample/Application.manifest
+++ b/CppXAMLSample/XamlIslandsSample/Application.manifest
@@ -6,7 +6,9 @@
       <!--This Id value indicates the application supports Windows 10 functionality -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
       <!-- See https://docs.microsoft.com/windows/win32/sbscs/application-manifests#maxversiontested before changing this value -->
-      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.18362.0" />
+      <!-- Enables Segoe UI Variable font on Windows 11 -->
+      <maxversiontested Id="10.0.22000.0" />
     </application>
   </compatibility>
 

--- a/CppXAMLSample/XamlIslandsSample/Application.manifest
+++ b/CppXAMLSample/XamlIslandsSample/Application.manifest
@@ -3,7 +3,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
     <application> 
-      <!--This Id value indicates the application supports Windows 10 functionality -->
+      <!-- This Id value indicates the application supports Windows 10 functionality -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
       <!-- See https://docs.microsoft.com/windows/win32/sbscs/application-manifests#maxversiontested before changing this value -->
       <maxversiontested Id="10.0.18362.0" />

--- a/Playground/Application.manifest
+++ b/Playground/Application.manifest
@@ -9,7 +9,9 @@
         WARNING - DO NOT CHANGE THE maxversiontested VALUE 
         Microsoft internal - see https://task.ms/33672605
       -->
-      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.18362.0" />
+      <!-- Enables Segoe UI Variable font on Windows 11 -->
+      <maxversiontested Id="10.0.22000.0" />
     </application>
   </compatibility>
 

--- a/Playground/Application.manifest
+++ b/Playground/Application.manifest
@@ -3,7 +3,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
     <application> 
-      <!--This Id value indicates the application supports Windows 10 functionality -->
+      <!-- This Id value indicates the application supports Windows 10 functionality -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
       <!-- 
         WARNING - DO NOT CHANGE THE maxversiontested VALUE 

--- a/inc/xaml-islands.manifest
+++ b/inc/xaml-islands.manifest
@@ -7,7 +7,9 @@
         WARNING - DO NOT CHANGE THE maxversiontested VALUE 
         Microsoft internal - see https://task.ms/33672605
       -->
-      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.18362.0" />
+      <!-- Enables Segoe UI Variable font on Windows 11 -->
+      <maxversiontested Id="10.0.22000.0" />
     </application>
   </compatibility>
 </assembly>

--- a/inc/xaml-islands.manifest
+++ b/inc/xaml-islands.manifest
@@ -1,7 +1,7 @@
 ﻿<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!--This Id value indicates the application supports Windows 10 functionality -->
+      <!-- This Id value indicates the application supports Windows 10 functionality -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
       <!-- 
         WARNING - DO NOT CHANGE THE maxversiontested VALUE 

--- a/readme.md
+++ b/readme.md
@@ -241,9 +241,11 @@ Things you'll need to worry about:
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
     <application> 
-      <!--This Id value indicates the application supports Windows 10 functionality -->
+      <!-- This Id value indicates the application supports Windows 10 functionality -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
-      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.18362.0" />
+      <!-- Enables Segoe UI Variable font on Windows 11 -->
+      <maxversiontested Id="10.0.22000.0" />
     </application>
   </compatibility>
 


### PR DESCRIPTION
To make Segoe UI Variable used as the default font on Windows 11, I’ve added 10.0.22000.0 to the maxversiontested array in the manifest.